### PR TITLE
fix package URL on setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -15,7 +15,7 @@ setuptools.setup(
     """,
     long_description=long_description,
     long_description_content_type="text/markdown",
-    url="https://github.com/whylabs/whylogs",
+    url="https://github.com/whylabs/airflow-provider-whylogs",
     install_requires=[
         "apache-airflow>=2.0",
         "whylogs[viz, s3]>=1.0.10"


### PR DESCRIPTION
details: previously this was pointing to whylogs' URL, now fixed to this package's