### PR TITLE
Feat: adding ability to parse macros

### DIFF
--- a/.github/workflows/provider-ci.yml
+++ b/.github/workflows/provider-ci.yml
@@ -28,6 +28,9 @@ jobs:
 
       - name: Install dependencies
         run: make dev-setup
-
+      
+      - name: Run lint
+        run: make lint
+      
       - name: Run tests
         run: make test

--- a/Makefile
+++ b/Makefile
@@ -8,6 +8,13 @@ dev-setup: ## Prepares a fresh development environment
 test: ## Runs necessary tests on the current environment
 	. .venv/bin/activate && py.test tests/
 	
+
+lint: ## Runs linter on the current environment
+	( \
+		. .venv/bin/activate; \
+		python3 -m pyright; \
+	)
+
 dist: clean  ## Builds the package with the version described on ./VERSION
 	( \
 		. .venv/bin/activate; \

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,7 @@
+[tool.pyright]
+include = ["whylogs_container"]
+typeCheckingMode = "strict"
+
+reportMissingTypeStubs = false
+reportMissingParameterType = false
+reportMissingTypeArgumet = false

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 -e .
 pytest==7.1.2
 build==0.8.0
+pyright==1.1.338


### PR DESCRIPTION
- Per a [community request](https://rsqrd-ai.slack.com/archives/C01BMDKKBMZ/p1701162527675909), this PR adds the ability to parse Airflow macros (based on Jinja templating). That is done by adding the `template_fields` argument as a `typing.Sequence`, as documented by Airflow [here](https://airflow.apache.org/docs/apache-airflow/stable/templates-ref.html)
- added pyright as the linter for the CI pipeline
- refactors to the codebase based on pyright